### PR TITLE
Fixing type 'finaly' to 'finally'

### DIFF
--- a/Classes/Promise.swift
+++ b/Classes/Promise.swift
@@ -11,7 +11,7 @@ import Foundation
 typealias thenClosure = (AnyObject?) -> (AnyObject?)
 typealias thenClosureNoReturn = (AnyObject?) -> ()
 typealias catchClosure = (AnyObject?) -> ()
-typealias finalyClosure = () -> ()
+typealias finallyClosure = () -> ()
 
 typealias promiseClosure = ( (AnyObject?) -> (), (AnyObject?) -> () ) -> ()
 
@@ -49,7 +49,7 @@ class Deferred: Promise {
         return promise.catch(catch)
     }
     
-    override func finally(finally: finalyClosure) -> Promise {
+    override func finally(finally: finallyClosure) -> Promise {
         return promise.finally(finally)
     }
     
@@ -59,7 +59,7 @@ class Promise {
 
     var thens = Array<thenClosure>()
     var cat: catchClosure?
-    var fin: finalyClosure?
+    var fin: finallyClosure?
  
     var value: AnyObject?
 
@@ -118,7 +118,7 @@ class Promise {
         return self
     }
     
-    func finally(finally: finalyClosure) -> Promise {
+    func finally(finally: finallyClosure) -> Promise {
         if (self.fin? != nil) { return self }
         
         self.sync { () in
@@ -259,27 +259,27 @@ extension Promise {
 //        private func then(value: AnyObject?) -> Promise {
 //            self.sync { () in
 //                self.numberOfThens += 1
-//                
+//
 //                if (self.total >= self.promiseCount) {
 //                    if (self.status == .PENDING) {
 //                        self.doResolve(nil, shouldRunFinally: false)
 //                    }
-//                    
+//
 //                    self.doFinally(self)
 //                }
 //            }
-//            
+//
 //            return self // TODO: Should this really turn self?
 //        }
         
 //        private func catch(value: AnyObject?) {
 //            self.sync { () in
 //                self.numberOfCatches += 1
-//                
+//
 //                if (self.status == .PENDING) {
 //                    self.doReject(nil, shouldRunFinally: false)
 //                }
-//                
+//
 //                if (self.total >= self.promiseCount) {
 //                    self.doFinally(self)
 //                }


### PR DESCRIPTION
I also reviewed the rest of the repository. Seems like some of your commits have made it more in line with what I had been thinking before. Specifically, moving the logic for `then`s, etc, out of the Enum status. It still seems to me that it'd be best to have a class per file (remove Deferred from Promise), but I'm not sure how the whole importing stuff works for that. Also, does Deferred extend Promise? I'm not super familiar with the syntax yet, but it seemed that way. If so, should it? Seems a bit strange that it would. 

Sorry for the extra space changes in the commit, apparently Xcode formatted the file while I had it open, and I didn't notice while committing.
